### PR TITLE
Fix setup guide for conda

### DIFF
--- a/user/setup/conda.rst
+++ b/user/setup/conda.rst
@@ -9,7 +9,7 @@ Conda |linux| |windows| |apple|
 Anaconda provides packages for `NEST Desktop <https://anaconda.org/conda-forge/nest-desktop>`__.
 and `NEST Simulator <https://anaconda.org/conda-forge/nest-simulator>`__.
 These packages can be installed with Conda (from :bdg:`conda-forge`).
-Since NEST 3, the API server (i.e. :bdg:`NEST Server`) is implemented which is necessary for :bdg:`NEST Desktop`.
+Since NEST 3, the API server (i.e. :bdg:`NEST Server`) is included which is necessary for :bdg:`NEST Desktop`.
 
 |br|
 
@@ -23,8 +23,8 @@ Add channel for :bdg:`conda-forge`:
 
    .. code-block:: bash
 
-   conda config --add channels conda-forge
-   conda config --set channel_priority strict
+      conda config --add channels conda-forge
+      conda config --set channel_priority strict
 
 |br|
 

--- a/user/setup/conda.rst
+++ b/user/setup/conda.rst
@@ -8,9 +8,23 @@ Conda |linux| |windows| |apple|
 
 Anaconda provides packages for `NEST Desktop <https://anaconda.org/conda-forge/nest-desktop>`__.
 and `NEST Simulator <https://anaconda.org/conda-forge/nest-simulator>`__.
-These packages can be installed with Conda.
-We highly recommend installing at least version 3 of NEST.
-Since NEST 3, the API server (i.e., NEST Server) is already implemented.
+These packages can be installed with Conda (from :bdg:`conda-forge`).
+Since NEST 3, the API server (i.e. :bdg:`NEST Server`) is implemented which is necessary for :bdg:`NEST Desktop`.
+
+|br|
+
+Prequistion for conda-forge
+---------------------------
+
+`Conda-forge` is a collection of packages led by the community (https://conda-forge.org/).
+By default :bdg:`conda` cannot install packages from the :bdg:`conda-forge`.
+
+Add channel for :bdg:`conda-forge`:
+
+   .. code-block:: bash
+
+   conda config --add channels conda-forge
+   conda config --set channel_priority strict
 
 |br|
 


### PR DESCRIPTION
`nest-simulator` and `nest-desktop` are hosted on `conda-forge` only. 
The user needs to add channel `conda-forge` that it is able to install both packages.

Fix https://github.com/nest-desktop/nest-desktop/issues/561.